### PR TITLE
feat: add multiple Terraform modules for AWS resources

### DIFF
--- a/repositories/locals.tf
+++ b/repositories/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  github_checks = [
+    {
+      context : "commitlint",
+      integration_id : 15368
+    },
+    {
+      context : "pre-commit",
+      integration_id : 15368
+    }
+  ]
+}

--- a/repositories/main.tf
+++ b/repositories/main.tf
@@ -12,24 +12,218 @@ terraform {
   }
 }
 
-module "cicd" {
-  source      = "./repository"
-  name        = "cicd"
-  description = "CI/CD setup for Opzkit"
-  additional_github_checks = [
-    {
-      context : "commitlint",
-      integration_id : 15368
-    },
-    {
-      context : "pre-commit",
-      integration_id : 15368
-    }
-  ]
+
+# module "tf-template" {
+#   source                   = "./repository"
+#   name                     = "tf-template"
+#   additional_github_checks = local.github_checks
+# }
+
+module "terraform-aws-k8s-addons-grafana-agent-operator" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-grafana-agent-operator"
+  additional_github_checks = local.github_checks
 }
 
 module "renovate-config" {
-  source      = "./repository"
-  name        = "renovate-config"
-  description = "Shared config for renovate bot"
+  source                   = "./repository"
+  name                     = "renovate-config"
+  description              = "Shared config for renovate bot"
+  additional_github_checks = local.github_checks
+}
+
+module "cicd" {
+  source                   = "./repository"
+  name                     = "cicd"
+  description              = "CI/CD setup for Opzkit"
+  additional_github_checks = local.github_checks
+}
+
+module "pre-commit-buildkite-plugin" {
+  source = "./repository"
+  name   = "pre-commit-buildkite-plugin"
+  additional_github_checks = concat(local.github_checks,
+    [
+      {
+        context        = "plugin-linter"
+        integration_id = 15368
+        }, {
+        context        = "plugin-tester"
+        integration_id = 15368
+      }
+  ])
+}
+
+module "terraform-aws-k8s-addons-aws-sso" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-aws-sso"
+  additional_github_checks = local.github_checks
+}
+
+module "github" {
+  source                   = "./repository"
+  name                     = "github"
+  additional_github_checks = local.github_checks
+}
+
+module "example" {
+  source                   = "./repository"
+  name                     = "example"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-k8s-addons-cluster-autoscaler" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-cluster-autoscaler"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-k8s-addons-grafana-k8s-monitoring" {
+  source = "./repository"
+  name   = "terraform-aws-k8s-addons-grafana-k8s-monitoring"
+  additional_github_checks = concat(local.github_checks, [
+    {
+      context        = "build"
+      integration_id = 15368
+      }, {
+      context        = "terrascan"
+      integration_id = 15368
+    }
+  ])
+}
+
+module "govulncheck-action" {
+  source                   = "./repository"
+  name                     = "govulncheck-action"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-k8s-addons-keda" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-keda"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-k8s-addons-external-secrets-operator" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-external-secrets-operator"
+  additional_github_checks = local.github_checks
+}
+
+module "godeadcode-action" {
+  source                   = "./repository"
+  name                     = "godeadcode-action"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-k8s-addons-github-runners-controller" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-github-runners-controller"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-cloudamqp-rabbitmq" {
+  source                   = "./repository"
+  name                     = "terraform-cloudamqp-rabbitmq"
+  additional_github_checks = local.github_checks
+}
+
+module "go-license-check-action" {
+  source                   = "./repository"
+  name                     = "go-license-check-action"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-kops-state-store" {
+  source = "./repository"
+  name   = "terraform-aws-kops-state-store"
+  additional_github_checks = concat(local.github_checks, [
+    {
+      context        = "build"
+      integration_id = 15368
+      }, {
+      context        = "terrascan"
+      integration_id = 15368
+    }
+  ])
+}
+
+module "terraform-aws-k8s-network" {
+  source = "./repository"
+  name   = "terraform-aws-k8s-network"
+  additional_github_checks = concat(local.github_checks, [
+    {
+      context        = "build"
+      integration_id = 15368
+      }, {
+      context        = "terrascan"
+      integration_id = 15368
+    }
+  ])
+}
+
+module "terraform-aws-k8s" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-k8s-addons-fluentbit" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-fluentbit"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-k8s-addons-external-dns" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-external-dns"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-rds-instance-postgresql" {
+  source                   = "./repository"
+  name                     = "terraform-aws-rds-instance-postgresql"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-rds-instance-mysql" {
+  source                   = "./repository"
+  name                     = "terraform-aws-rds-instance-mysql"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-k8s-addons-github-runners" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-github-runners"
+  additional_github_checks = local.github_checks
+}
+
+module "nodeamqp" {
+  source                   = "./repository"
+  name                     = "nodeamqp"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-k8s-addons-argocd" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-argocd"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-elasticache-redis" {
+  source                   = "./repository"
+  name                     = "terraform-aws-elasticache-redis"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-dns-validated-certificate" {
+  source                   = "./repository"
+  name                     = "terraform-aws-dns-validated-certificate"
+  additional_github_checks = local.github_checks
+}
+
+module "terraform-aws-aurora-mysql" {
+  source                   = "./repository"
+  name                     = "terraform-aws-aurora-mysql"
+  additional_github_checks = local.github_checks
 }


### PR DESCRIPTION
Add various Terraform modules including Grafana agent operator, 
renovate configuration, CI/CD setup, and Kubernetes addons. 
Update the structure for better organization and maintainability, 
and ensure additional GitHub checks align with local configurations.