### PR TITLE
feat: add archived variable for GitHub repository

### DIFF
--- a/repositories/main.tf
+++ b/repositories/main.tf
@@ -23,6 +23,7 @@ module "terraform-aws-k8s-addons-grafana-agent-operator" {
   source                   = "./repository"
   name                     = "terraform-aws-k8s-addons-grafana-agent-operator"
   additional_github_checks = local.tf_github_checks
+  archived                 = true
 }
 
 module "renovate-config" {

--- a/repositories/repository/github.tf
+++ b/repositories/repository/github.tf
@@ -17,7 +17,7 @@ resource "github_repository" "repository" {
 
   allow_merge_commit = false
   allow_auto_merge   = true
-
+  archived           = var.archived
   # security_and_analysis {
   # advanced_security {
   #   status = "enabled"

--- a/repositories/repository/vars.tf
+++ b/repositories/repository/vars.tf
@@ -26,4 +26,10 @@ variable "additional_github_checks" {
   default     = []
 }
 
+variable "archived" {
+  type        = bool
+  default     = false
+  nullable    = true
+  description = "If the repository should be archived"
+}
 # More config (rules and so on)...


### PR DESCRIPTION
Add a new boolean variable `archived` to control the archiving status 
of the GitHub repository. The variable is set to false by default 
and allows nullable configurations. Update the GitHub repository 
resource to use this variable, ensuring compatibility with the 
archive feature. Set `archived` to true in the main module for 
the Grafana Agent Operator to reflect its intended status.