### PR TITLE
fix: update argocd-bootstrap-template GitHub checks

### DIFF
--- a/repositories/main.tf
+++ b/repositories/main.tf
@@ -192,7 +192,7 @@ module "terraform-aws-k8s-argocd-cluster-secret" {
 module "argocd-bootstrap-template" {
   source                   = "./repository"
   name                     = "argocd-bootstrap-template"
-  additional_github_checks = local.tf_github_checks
+  additional_github_checks = local.default_github_checks
 }
 
 module "opzkit_github_io" {


### PR DESCRIPTION
Replace `local.tf_github_checks` with `local.default_github_checks` in the 
`argocd-bootstrap-template` module to ensure consistency in GitHub checks 
across modules. This change simplifies the configuration and aligns with 
current best practices.