### PR TITLE
feat: add descheduler addon module to main.tf

### DIFF
--- a/repositories/main.tf
+++ b/repositories/main.tf
@@ -189,6 +189,12 @@ module "terraform-aws-k8s-argocd-cluster-secret" {
   additional_github_checks = local.tf_github_checks
 }
 
+module "terraform-aws-k8s-addons-descheduler" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-descheduler"
+  additional_github_checks = local.tf_github_checks
+}
+
 module "argocd-bootstrap-template" {
   source                   = "./repository"
   name                     = "argocd-bootstrap-template"


### PR DESCRIPTION
Add a new module for the descheduler addon to main.tf. This change 
enhances the Kubernetes cluster setup by allowing for automated 
descheduling of pods, improving resource management and 
availability within the cluster. The additional GitHub checks 
are maintained for consistency and quality assurance.