### PR TITLE
feat: add ArgoCD cluster secrets module to main config

### DIFF
--- a/repositories/main.tf
+++ b/repositories/main.tf
@@ -195,6 +195,12 @@ module "terraform-aws-k8s-addons-descheduler" {
   additional_github_checks = local.tf_github_checks
 }
 
+module "terraform-aws-k8s-addons-argocd-cluster-secrets" {
+  source                   = "./repository"
+  name                     = "terraform-aws-k8s-addons-argocd-cluster-secrets"
+  additional_github_checks = local.tf_github_checks
+}
+
 module "argocd-bootstrap-template" {
   source                   = "./repository"
   name                     = "argocd-bootstrap-template"


### PR DESCRIPTION
Adds a new module for ArgoCD cluster secrets to the main Terraform 
configuration. This change simplifies the management of Kubernetes 
add-ons related to ArgoCD and ensures the inclusion of additional 
GitHub checks for improved security and compliance.
